### PR TITLE
Fix block rewards panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,6 +3814,7 @@ dependencies = [
  "axum",
  "clap",
  "env_logger",
+ "futures",
  "log",
  "prometheus-client",
  "reqwest 0.12.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0.132"
 reqwest = { version = "0.12.9", features = ["json"] }
+futures = "0.3"
 
 [[bin]]
 name = "solana-validator-exporter"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,4 +1,0 @@
-rpc_url: "YOUR_RPC_URL"
-port: 9090
-vote_account: "YOUR_VOTE_ACCOUNT_PUBKEY"
-identity_account: "YOUR_IDENTITY_ACCOUNT_PUBKEY" 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,4 @@
+rpc_url: "YOUR_RPC_URL"
+port: 9090
+vote_account: "YOUR_VOTE_ACCOUNT_PUBKEY"
+identity_account: "YOUR_IDENTITY_ACCOUNT_PUBKEY" 

--- a/src/solana/validator.rs
+++ b/src/solana/validator.rs
@@ -278,6 +278,13 @@ impl SolanaClient {
         let mut sorted_slots = slots_to_fetch;
         sorted_slots.sort_by(|a, b| b.cmp(a));
 
+        // Log how far behind we are from the current slot
+        if let Some(&newest_target_slot) = sorted_slots.first() {
+            let slots_behind = current_slot.saturating_sub(newest_target_slot);
+            info!("Latest Slot: {} | Target Slot: {} is {} slots behind | Fetching {} total slots", 
+                  current_slot, newest_target_slot, slots_behind, sorted_slots.len());
+        }
+
         // Process in batches to avoid overwhelming the RPC
         const BATCH_SIZE: usize = 10;
         let total_start = std::time::Instant::now();

--- a/src/solana/validator.rs
+++ b/src/solana/validator.rs
@@ -224,7 +224,14 @@ impl SolanaClient {
             )
             .await
         {
-            Ok(block) => Ok(block.rewards.ok_or_else(|| "Error fetching rewards")?[0].lamports),
+            Ok(block) => {
+                let rewards = block.rewards.ok_or_else(|| "Error fetching rewards")?;
+                if rewards.is_empty() {
+                    Ok(0)
+                } else {
+                    Ok(rewards[0].lamports)
+                }
+            },
             Err(e) => {
                 let error = e.to_string();
                 if error.contains("skipped") {


### PR DESCRIPTION
fixed the issue that resulted into this error message:

```
   1: core::panicking::panic_fmt
   2: core::panicking::panic_bounds_check
   3: solana_validator_exporter::metrics::exporter::Metrics::run_loop::{{closure}}
   4: tokio::runtime::task::core::Core<T,S>::poll
   5: tokio::runtime::task::harness::Harness<T,S>::poll
   6: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
   7: tokio::runtime::scheduler::multi_thread::worker::Context::run
   8: tokio::runtime::context::scoped::Scoped<T>::set
   9: tokio::runtime::context::runtime::enter_runtime
  10: tokio::runtime::scheduler::multi_thread::worker::run
  11: tokio::runtime::task::core::Core<T,S>::poll
  12: tokio::runtime::task::harness::Harness<T,S>::poll
  13: tokio::runtime::blocking::pool::Inner::run
```
  
made it faster with using get_block_rewards_sum to be able to fetch slots in batches.

improved logging, added some informations to it:

```
[2025-06-02T12:51:15Z INFO  solana_validator_exporter] Starting exporter!
[2025-06-02T12:51:17Z INFO  solana_validator_exporter::solana::validator] Latest Slot: 344124268 | Target Slot: 344123979 is 289 slots behind | Fetching 12 total slots
[2025-06-02T12:51:17Z INFO  solana_validator_exporter::solana::validator] Fetching block rewards for 10 slots in parallel: [344123979, 344123978, 344123977, 344123976, 344123691, 344123690, 344123689, 344123688, 344123299, 344123298]
[2025-06-02T12:51:18Z INFO  solana_validator_exporter::solana::validator] Fetched 10 out of 10 slots in 1.046518211s (avg: 104.6ms per slot)
[2025-06-02T12:51:18Z INFO  solana_validator_exporter::solana::validator] Fetching block rewards for 2 slots in parallel: [344123297, 344123296]
[2025-06-02T12:51:19Z INFO  solana_validator_exporter::solana::validator] Fetched 2 out of 2 slots in 428.458338ms (avg: 214.0ms per slot)
[2025-06-02T12:51:19Z INFO  solana_validator_exporter::solana::validator] Total: fetched 12 slots in 1.677528149s (avg: 139.8ms per slot)
[2025-06-02T12:51:55Z INFO  solana_validator_exporter::solana::validator] Latest Slot: 344124365 | Target Slot: 344124365 is 0 slots behind | Fetching 2 total slots
[2025-06-02T12:51:55Z INFO  solana_validator_exporter::solana::validator] Fetching block rewards for 2 slots in parallel: [344124365, 344124364]
[2025-06-02T12:51:56Z INFO  solana_validator_exporter::solana::validator] Fetched 2 out of 2 slots in 358.538695ms (avg: 179.0ms per slot)
[2025-06-02T12:51:56Z INFO  solana_validator_exporter::solana::validator] Total: fetched 2 slots in 458.975078ms (avg: 229.0ms per slot)
[2025-06-02T12:51:58Z INFO  solana_validator_exporter::solana::validator] Latest Slot: 344124373 | Target Slot: 344124367 is 6 slots behind | Fetching 2 total slots
[2025-06-02T12:51:58Z INFO  solana_validator_exporter::solana::validator] Fetching block rewards for 2 slots in parallel: [344124367, 344124366]
[2025-06-02T12:51:59Z INFO  solana_validator_exporter::solana::validator] Fetched 2 out of 2 slots in 282.192626ms (avg: 141.0ms per slot)
[2025-06-02T12:51:59Z INFO  solana_validator_exporter::solana::validator] Total: fetched 2 slots in 383.599208ms (avg: 191.5ms per slot)
```