### PR TITLE
#7 add a new metric solana_voting_status

### DIFF
--- a/src/metrics/exporter.rs
+++ b/src/metrics/exporter.rs
@@ -52,6 +52,7 @@ pub struct Metrics {
     pub epoch_block_rewards: Family<MethodLabels, Gauge>,
     pub ms_to_next_slot: Family<MethodLabels, Gauge>,
     pub last_block_rewards: Family<MethodLabels, Gauge>,
+    pub voting_status: Family<MethodLabels, Gauge>,
 }
 
 impl Metrics {
@@ -74,6 +75,7 @@ impl Metrics {
             epoch_block_rewards: Family::default(),
             ms_to_next_slot: Family::default(),
             last_block_rewards: Family::default(),
+            voting_status: Family::default(),
         }
     }
 
@@ -144,6 +146,12 @@ impl Metrics {
             "solana_last_block_rewards",
             "Average of last non-zero block rewards",
             self.last_block_rewards.clone(),
+        );
+
+        state.registry.register(
+            "solana_voting_status",
+            "Validator voting status (-1=not found from the RPC response, 0=delinquent, 1=voting normally)",
+            self.voting_status.clone(),
         );
     }
 
@@ -330,6 +338,18 @@ impl Metrics {
 
                 if let Some(usd_price) = usd_price {
                     self.set_usd_price(usd_price);
+                }
+
+                let voting_status = match client.get_voting_status().await {
+                    Ok(status) => Some(status),
+                    Err(e) => {
+                        error!("Error fetching voting status: {}", e);
+                        None
+                    }
+                };
+
+                if let Some(voting_status) = voting_status {
+                    self.set_voting_status(voting_status);
                 }
 
                 // Sleep between metric updates
@@ -519,6 +539,15 @@ impl Metrics {
                 vote_account: self.vote_account.clone(),
             })
             .set(last_block_rewards);
+    }
+
+    pub fn set_voting_status(&self, status: i64) {
+        self.voting_status
+            .get_or_create(&MethodLabels {
+                network: self.network.clone(),
+                vote_account: self.vote_account.clone(),
+            })
+            .set(status);
     }
 }
 

--- a/src/metrics/exporter.rs
+++ b/src/metrics/exporter.rs
@@ -56,7 +56,12 @@ pub struct Metrics {
 }
 
 impl Metrics {
-    pub fn new(network: String, rpc_url: String, identity_account: String, vote_account: String) -> Metrics {
+    pub fn new(
+        network: String,
+        rpc_url: String,
+        identity_account: String,
+        vote_account: String,
+    ) -> Metrics {
         Metrics {
             network,
             rpc_url,
@@ -81,7 +86,7 @@ impl Metrics {
 
     pub async fn init_registry(&self, shared_state: Arc<Mutex<AppState>>) {
         let mut state = shared_state.lock().await;
-        
+
         state
             .registry
             .register("solana_slot", "Slot of cluster", self.slot.clone());
@@ -164,8 +169,9 @@ impl Metrics {
             );
 
             // Create a channel for communicating current slot, epoch, and leader slots to background task
-            let (slot_tx, mut slot_rx) = tokio::sync::mpsc::unbounded_channel::<(u64, u64, Vec<u64>)>();
-            
+            let (slot_tx, mut slot_rx) =
+                tokio::sync::mpsc::unbounded_channel::<(u64, u64, Vec<u64>)>();
+
             // Spawn background task for block rewards fetching
             let mut bg_client = solana::validator::SolanaClient::new(
                 &self.rpc_url,
@@ -176,10 +182,13 @@ impl Metrics {
             tokio::spawn(async move {
                 while let Some((current_slot, current_epoch, leader_slots)) = slot_rx.recv().await {
                     if !leader_slots.is_empty() {
-                        match bg_client.get_block_rewards_sum(current_slot, current_epoch, leader_slots).await {
+                        match bg_client
+                            .get_block_rewards_sum(current_slot, current_epoch, leader_slots)
+                            .await
+                        {
                             Ok(block_rewards) => {
                                 bg_self.set_epoch_block_rewards(block_rewards);
-                                
+
                                 match bg_client.get_last_block_rewards().await {
                                     Ok(last_rewards) => {
                                         bg_self.set_last_block_rewards(last_rewards);

--- a/src/solana/validator.rs
+++ b/src/solana/validator.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
-use log::{debug, info, error};
+use futures;
+use log::{debug, error, info};
 use serde::Deserialize;
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_rpc_client_api::config::{
@@ -17,7 +18,6 @@ use solana_sdk::sysvar::clock::Clock;
 use solana_sdk::sysvar::stake_history;
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use futures;
 use tokio;
 
 pub struct SolanaClient {
@@ -79,7 +79,9 @@ impl SolanaClient {
         ))
     }
 
-    pub async fn get_stake_details(&self) -> Result<StakeState, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_stake_details(
+        &self,
+    ) -> Result<StakeState, Box<dyn std::error::Error + Send + Sync>> {
         let program_accounts_config = RpcProgramAccountsConfig {
             account_config: RpcAccountInfoConfig {
                 encoding: Some(solana_account_decoder::UiAccountEncoding::Base64),
@@ -161,7 +163,9 @@ impl SolanaClient {
         }
         Ok(stake_details)
     }
-    pub async fn get_identity_balance(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_identity_balance(
+        &self,
+    ) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
         let balance = self
             .client
             .get_balance(&Pubkey::from_str(&self.identity_account)?)
@@ -175,7 +179,9 @@ impl SolanaClient {
             .await?;
         Ok(balance)
     }
-    pub async fn get_leader_info(&self) -> Result<Vec<u64>, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_leader_info(
+        &self,
+    ) -> Result<Vec<u64>, Box<dyn std::error::Error + Send + Sync>> {
         let epoch_info = self.client.get_epoch_info().await?;
         let epoch_schedule = self.client.get_epoch_schedule().await?;
         let first_slot_in_epoch = epoch_schedule.get_first_slot_in_epoch(epoch_info.epoch);
@@ -199,7 +205,9 @@ impl SolanaClient {
         Ok(leader_slots)
     }
 
-    pub async fn get_block_production(&self) -> Result<(usize, usize), Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_block_production(
+        &self,
+    ) -> Result<(usize, usize), Box<dyn std::error::Error + Send + Sync>> {
         let blocks = self.client.get_block_production().await?;
         let my_blocks = blocks
             .value
@@ -214,7 +222,10 @@ impl SolanaClient {
         Ok(bp)
     }
 
-    pub async fn get_block_rewards(&self, slot: u64) -> Result<i64, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_block_rewards(
+        &self,
+        slot: u64,
+    ) -> Result<i64, Box<dyn std::error::Error + Send + Sync>> {
         match self
             .client
             .get_block_with_config(
@@ -235,7 +246,7 @@ impl SolanaClient {
                 } else {
                     Ok(rewards[0].lamports)
                 }
-            },
+            }
             Err(e) => {
                 let error = e.to_string();
                 if error.contains("skipped") {
@@ -266,9 +277,9 @@ impl SolanaClient {
         let slots_to_fetch: Vec<u64> = leader_slots
             .iter()
             .filter(|&slot| {
-                !self.block_rewards.contains_key(slot) 
-                && *slot <= current_slot 
-                && *slot > current_slot.saturating_sub(1000) // Only fetch recent slots
+                !self.block_rewards.contains_key(slot)
+                    && *slot <= current_slot
+                    && *slot > current_slot.saturating_sub(1000) // Only fetch recent slots
             })
             .copied()
             .collect();
@@ -285,19 +296,28 @@ impl SolanaClient {
         // Log how far behind we are from the current slot
         if let Some(&newest_target_slot) = sorted_slots.first() {
             let slots_behind = current_slot.saturating_sub(newest_target_slot);
-            info!("Latest Slot: {} | Target Slot: {} is {} slots behind | Fetching {} total slots", 
-                  current_slot, newest_target_slot, slots_behind, sorted_slots.len());
+            info!(
+                "Latest Slot: {} | Target Slot: {} is {} slots behind | Fetching {} total slots",
+                current_slot,
+                newest_target_slot,
+                slots_behind,
+                sorted_slots.len()
+            );
         }
 
         // Process in batches to avoid overwhelming the RPC
         const BATCH_SIZE: usize = 10;
         let total_start = std::time::Instant::now();
         let mut total_fetched = 0;
-        
+
         for batch in sorted_slots.chunks(BATCH_SIZE) {
             let batch_start = std::time::Instant::now();
-            info!("Fetching block rewards for {} slots in parallel: {:?}", batch.len(), batch);
-            
+            info!(
+                "Fetching block rewards for {} slots in parallel: {:?}",
+                batch.len(),
+                batch
+            );
+
             // Create futures for parallel fetching
             let futures: Vec<_> = batch
                 .iter()
@@ -306,7 +326,7 @@ impl SolanaClient {
 
             // Execute all requests in parallel
             let results = futures::future::join_all(futures).await;
-            
+
             let mut batch_success_count = 0;
             // Process results
             for (i, result) in results.into_iter().enumerate() {
@@ -324,10 +344,14 @@ impl SolanaClient {
             }
 
             let batch_duration = batch_start.elapsed();
-            info!("Fetched {} out of {} slots in {:?} (avg: {:.1}ms per slot)", 
-                  batch_success_count, batch.len(), batch_duration,
-                  batch_duration.as_millis() as f64 / batch.len() as f64);
-            
+            info!(
+                "Fetched {} out of {} slots in {:?} (avg: {:.1}ms per slot)",
+                batch_success_count,
+                batch.len(),
+                batch_duration,
+                batch_duration.as_millis() as f64 / batch.len() as f64
+            );
+
             total_fetched += batch_success_count;
 
             // Add a small delay between batches to be nice to the RPC
@@ -336,16 +360,22 @@ impl SolanaClient {
 
         let total_duration = total_start.elapsed();
         if total_fetched > 0 {
-            info!("Total: fetched {} slots in {:?} (avg: {:.1}ms per slot)", 
-                  total_fetched, total_duration,
-                  total_duration.as_millis() as f64 / total_fetched as f64);
+            info!(
+                "Total: fetched {} slots in {:?} (avg: {:.1}ms per slot)",
+                total_fetched,
+                total_duration,
+                total_duration.as_millis() as f64 / total_fetched as f64
+            );
         }
 
         let sum: i64 = self.block_rewards.values().sum();
         Ok(sum)
     }
 
-    pub async fn get_jito_tips(&self, epoch: i64) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_jito_tips(
+        &self,
+        epoch: i64,
+    ) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
         let (addr, _) = Pubkey::find_program_address(
             &[
                 b"TIP_DISTRIBUTION_ACCOUNT",
@@ -360,7 +390,9 @@ impl SolanaClient {
         Ok(balance)
     }
 
-    pub async fn get_vote_credit_rank(&self) -> Result<u32, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_vote_credit_rank(
+        &self,
+    ) -> Result<u32, Box<dyn std::error::Error + Send + Sync>> {
         let vote_accounts = self
             .client
             .get_vote_accounts_with_config(RpcGetVoteAccountsConfig {
@@ -439,7 +471,9 @@ impl SolanaClient {
         Ok(((next_slot - current_slot) * average_slot_time_ms) as i64)
     }
 
-    pub async fn get_last_block_rewards(&self) -> Result<i64, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_last_block_rewards(
+        &self,
+    ) -> Result<i64, Box<dyn std::error::Error + Send + Sync>> {
         let mut keys: Vec<u64> = self.block_rewards.keys().cloned().collect();
         keys.sort();
         let block_rewards: Vec<_> = keys

--- a/src/solana/validator.rs
+++ b/src/solana/validator.rs
@@ -455,4 +455,38 @@ impl SolanaClient {
         }
         Ok(sum / 4)
     }
+
+    pub async fn get_voting_status(&self) -> Result<i64, Box<dyn std::error::Error + Send + Sync>> {
+        let vote_accounts = self
+            .client
+            .get_vote_accounts_with_config(RpcGetVoteAccountsConfig {
+                keep_unstaked_delinquents: Some(true),
+                delinquent_slot_distance: Some(125),
+                ..RpcGetVoteAccountsConfig::default()
+            })
+            .await?;
+
+        // Check if the vote account is in the current (non-delinquent) list
+        let is_current = vote_accounts
+            .current
+            .iter()
+            .any(|vote_account| vote_account.vote_pubkey == self.vote_account);
+
+        if is_current {
+            Ok(1) // Voting normally
+        } else {
+            // Check if it's in the delinquent list
+            let is_delinquent = vote_accounts
+                .delinquent
+                .iter()
+                .any(|vote_account| vote_account.vote_pubkey == self.vote_account);
+
+            if is_delinquent {
+                Ok(0) // Not voting due to delinquency
+            } else {
+                // Validator not found in either list - possibly not a validator or other issue
+                Ok(-1)
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a new metric named `solana_voting_status`. It checks the response of the [getVoteAccounts RPC Method](https://solana.com/docs/rpc/http/getvoteaccounts) and shows whether a validator is normally voting or delinquent.

Example:
```
# HELP solana_voting_status Validator voting status (-1=not found from the RPC response, 0=not voting/delinquent, 1=voting normally).
# TYPE solana_voting_status gauge
solana_voting_status{network="mainnet",vote_account="<vote_account_address>"} 0
```